### PR TITLE
Adapt route handling

### DIFF
--- a/src/gorillalabs/tesla.clj
+++ b/src/gorillalabs/tesla.clj
@@ -8,9 +8,8 @@
     [gorillalabs.tesla.component.configuration :as config]
     [gorillalabs.tesla.component.metering :as metering]
     [gorillalabs.tesla.component.keep-alive :as keep-alive]
-    [gorillalabs.tesla.component.health :as health]
     [gorillalabs.tesla.component.handler :as handler]
-    [gorillalabs.tesla.component.httpkit :as httpkit]
+    [gorillalabs.tesla.component.health :as health]
     [gorillalabs.tesla.component.quartzite :as quartzite]
     [gorillalabs.tesla.component.mongo :as mongo]
     ))
@@ -30,7 +29,6 @@
        :health     #'health/health
        :metering   #'metering/metering
        :handler    #'handler/handler
-       :httpkit    #'httpkit/httpkit
        :quartzite  #'quartzite/quartzite
        :mongo      #'mongo/mongo
        }]
@@ -50,10 +48,9 @@
     (log/info "<- Stopping system.")
     (apply mnt/stop (concat (vals default-components) custom-components)))
 
-
   (defn start [& custom-components]
     (log/info "-> Starting system")
-    (apply mnt/start (concat (vals default-components) custom-components))
+    (apply mnt/start (concat (vals default-components) (vals (into {} custom-components))))
     (doseq [sig ["INT" "TERM"]]
       (reset! (beckon/signal-atom sig)
-              #{(partial apply stop custom-components)}))))
+              #{(partial apply stop (vals (into {} custom-components)))}))))

--- a/src/gorillalabs/tesla/component/health.clj
+++ b/src/gorillalabs/tesla/component/health.clj
@@ -36,7 +36,7 @@
   (let [healthy? (atom true)]
     (handler/register
         handler/handler
-        (config/config config/configuration [:health :path] "/health")
+        (config/config config/configuration [:health :path] "health")
         (handler/wrap-site #'handle))
     healthy?))
 
@@ -44,7 +44,7 @@
   (log/info "<- Stopping Healthcheck")
   (handler/deregister
     handler/handler
-    (config/config config/configuration [:health :path] "/health"))
+    (config/config config/configuration [:health :path] "health"))
   self)
 
 (mnt/defstate health

--- a/src/gorillalabs/tesla/component/httpkit.clj
+++ b/src/gorillalabs/tesla/component/httpkit.clj
@@ -31,7 +31,7 @@
 (defn- start []
   (log/info "-> starting httpkit")
   (let [server-config (server-config config/configuration)
-        routes @handler/handler
+        routes ["/" (apply hash-map @handler/handler)]
         _ (log/info "Starting httpkit with port " (server-config :port) " and bind " (server-config :ip) ".")
         server (httpkit/run-server (bidi.ring/make-handler routes) server-config)]
     server))


### PR DESCRIPTION
- Adapt route structure to allow more than one match
- remove http-kit component from default configuration as it needs to be started after all handlers has been registered
