### PR TITLE
Add basic authorization component

### DIFF
--- a/dev-resources/config@SYSTEM-ENV.edn
+++ b/dev-resources/config@SYSTEM-ENV.edn
@@ -2,6 +2,13 @@
  :status          {:url "/status"}
  :health          {:url "/health"}
 
+
+ :authorization   {:secret  "mytotallysuperdupermegasecret"
+                   :encryption {:alg :a256kw
+                                :enc :a128gcm}
+                   :authdata {:admin "secret"
+                              :test  "secret"}}
+
  ;;; metering
  :metering        {:reporter "console"
                    :console  {:interval 100}}

--- a/src/gorillalabs/tesla/component/authorization.clj
+++ b/src/gorillalabs/tesla/component/authorization.clj
@@ -1,0 +1,49 @@
+(ns gorillalabs.tesla.component.authorization
+  (:require [mount.core :as mnt]
+            [clojure.tools.logging :as log]
+            [gorillalabs.tesla.component.configuration :as config]
+            [gorillalabs.tesla.component.mongo :refer [mongo retrievePage retrieveItem]]
+            [buddy.sign.jwe :as jwe]
+            [clj-time.core :refer [hours from-now]]
+            [buddy.auth.backends.token :as auth]
+            [buddy.core.hash :as hash]
+            ))
+
+
+(def secret
+  (delay (let [secret? (config/config config/configuration [:authorization :secret])]
+           (when secret? (hash/sha256 secret?)))))
+
+(def encryption (delay (config/config config/configuration [:authorization :encryption])))
+(def authdata (delay (config/config config/configuration [:authorization :authdata])))
+
+(defn- unauthorized [& _] {:status 403 :body {:message "Unauthorized. Please login first."}})
+
+(defn authorize [username password]
+  (let [valid? (some-> (deref authdata)
+                       (get (keyword username))
+                       (= password))]
+    (when (and username password)
+      (if valid?
+        (let [claims {:user (keyword username)
+                      :exp  (-> 3 hours from-now)}]
+          (jwe/encrypt claims (deref secret) (deref encryption)))))))
+
+
+
+
+(defn- start []
+  (log/info "-> Starting authorization.")
+  (if (and secret encryption authdata)
+    (auth/jwe-backend {:secret               (deref secret)
+                       :options              (deref encryption)
+                       :unauthorized-handler unauthorized})
+    (log/error "Autorization needs to be configured first")))
+
+(defn- stop [self]
+  (log/info "<- Stopping authorization")
+  self)
+
+(mnt/defstate authorization
+              :start (start)
+              :stop (stop authorization))

--- a/src/gorillalabs/tesla/component/handler.clj
+++ b/src/gorillalabs/tesla/component/handler.clj
@@ -1,7 +1,11 @@
 (ns gorillalabs.tesla.component.handler
   (:require [mount.core :as mnt]
             [clojure.tools.logging :as log]
-            [ring.middleware.defaults :as ring-defaults]))
+            [ring.middleware.defaults :as ring-defaults]
+            [ring.middleware.json :refer [wrap-json-response wrap-json-params wrap-json-body]]
+            [buddy.auth.middleware :refer [wrap-authentication wrap-authorization]]
+            [buddy.auth :refer [authenticated? throw-unauthorized]]
+            ))
 
 
 (defmulti process (fn [handler _] handler))
@@ -37,12 +41,35 @@
               :start (start)
               :stop (stop))
 
-(defn wrap-api [handler]
-  (ring-defaults/wrap-defaults
-    handler
-    (assoc ring-defaults/secure-api-defaults
-      :static false
-      :proxy true)))
+(defn- wrap-block-not-authenticated-requests
+  [handler]
+  (fn [request]
+    (if-not (authenticated? request)
+      (throw-unauthorized)
+      (handler request))))
+
+(defn- wrap-common-handler
+  [handler]
+  (-> handler
+      (ring-defaults/wrap-defaults ring-defaults/site-defaults)
+      (wrap-json-body)
+      (wrap-json-params)
+      (wrap-json-response)
+      ))
+
+(defn wrap-secure-api [handler authorization]
+  (-> handler
+      (wrap-block-not-authenticated-requests)
+      (wrap-authentication authorization)
+      (wrap-authorization authorization)
+      (wrap-common-handler)
+      ))
+
+
+(defn wrap-insecure-api [handler]
+  (-> handler
+      (wrap-common-handler)
+))
 
 
 (defn wrap-site [handler]


### PR DESCRIPTION
This request adds a basic authorization component as well as the according handlers.
Note that the component is currenlty still configured via the config-file.
