### PR TITLE
Telemetry improvements

### DIFF
--- a/core/src/gorillalabs/tesla/component/telemetry.clj
+++ b/core/src/gorillalabs/tesla/component/telemetry.clj
@@ -32,7 +32,7 @@
 (defn- flush-queue [client queue]
   (let [events (drain-queue queue)]
     (when (and client (seq events))
-      (log/infof "Sending %d event(s) to telemetry backend..." (count events))
+      (log/debugf "Sending %d event(s) to telemetry backend..." (count events))
       (riemann/send-events client events))))
 
 (defn- prepare-event [telemetry event]
@@ -63,8 +63,8 @@
                       result  expr
                       elapsed (list '- (list 'System/currentTimeMillis) start)
                       values  (list 'merge props {:service identifier :metric elapsed :unit "ms" :type "timed"})]
-                (list 'log/infof "[%s] took %dms." identifier elapsed)
                 (list 'gorillalabs.tesla.component.telemetry/enqueue 'gorillalabs.tesla.component.telemetry/telemetry values)
+                (list 'log/debugf "[%s] took %dms." identifier elapsed)
                 result)
           expr)))
 

--- a/core/src/gorillalabs/tesla/component/telemetry.clj
+++ b/core/src/gorillalabs/tesla/component/telemetry.clj
@@ -2,10 +2,11 @@
 ;;;
 ;;; Sample configuration:
 ;;;
-;;; {:telemetry {:riemann  {:host "127.0.0.2" :port 5555}
-;;;              :host     "app.eu.backend42" ;; leave out for automatic hostname detection
-;;;              :prefix   "app.backend."     ;; automatically prefix all service names
-;;;              :interval 60                 ;; seconds
+;;; {:telemetry {:riemann    {:host "127.0.0.2" :port 5555}
+;;;              :host       "app.eu.backend42" ;; leave out for automatic hostname detection
+;;;              :prefix     "app.backend."     ;; automatically prefix all service names
+;;;              :interval   60                 ;; seconds
+;;;              :queue-size 1000               ;; how many messages can be buffered
 ;;;              }}
 
 (ns gorillalabs.tesla.component.telemetry
@@ -79,7 +80,7 @@
 (defn- start []
   (log/info "-> starting telemetry")
   (let [config     (config/config config/configuration [:telemetry])
-        queue      (chan (sliding-buffer 100))
+        queue      (chan (sliding-buffer (:queue-size config 1000)))
         killswitch (chan)
         client     (when (:riemann config) (riemann/tcp-client (:riemann config)))]
     (worker killswitch client queue (:interval config 30))


### PR DESCRIPTION
Seeing how our usecases now include lots and lots of small (quick) work units, it doesn't make sense to report the <Nms times to riemann. Also, we fill our logs with useless "[this] took 2ms." messages.

This PR bundles a couple of general improvements to the core/telemetry component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorillalabs/tesla/4)
<!-- Reviewable:end -->
