### PR TITLE
Flush telemetry buffer on shutdown

### DIFF
--- a/core/src/gorillalabs/tesla/component/telemetry.clj
+++ b/core/src/gorillalabs/tesla/component/telemetry.clj
@@ -104,6 +104,7 @@
   (log/info "<- stopping telemetry")
   (close! (:killswitch telemetry))
   (when-let [client (:r-client telemetry)]
+    (flush-queue client (:queue telemetry))
     (riemann/close! client)))
 
 (mnt/defstate telemetry


### PR DESCRIPTION
Not flushing the queue will potentially discard events if the application is shut down before the next sending iteration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorillalabs/tesla/6)
<!-- Reviewable:end -->
